### PR TITLE
Add support for modifications to SQLAlchemy result mechanics

### DIFF
--- a/sqlalchemy_foundationdb/compat.py
+++ b/sqlalchemy_foundationdb/compat.py
@@ -1,0 +1,6 @@
+from sqlalchemy import __version__ as sa_version
+import re
+
+sa_version = tuple(int(x) for x in re.findall(r'(\d+)', sa_version))
+sqla_09 = sa_version >= (0, 9, 0)
+sqla_10 = sa_version >= (1, 0, 0)


### PR DESCRIPTION
This is the first in a series of changes to allow FDB to work
with SQLAlchemy 1.0.   The change here uses a new mini-API
in sqlalchemy.sql.compiler in order to achieve the "nesting"
of result metadata within a single statement.

I might advise leaving this PR for the time being until I finalize what I'm doing with SQLAlchemy 1.0 in master.    There will also need to be changes to the ORM utilities as some signatures have changed there as well.